### PR TITLE
cmd: Add Output Option To `print` Subcommand

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/spf13/cobra"
+	"os"
+)
+
+var (
+	execCmdOutputFlag string
 )
 
 var printCmd = &cobra.Command{
@@ -13,11 +17,21 @@ var printCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		app := getAppFromContext(cmd.Context())
 		if snippet, ok := app.LookupAndCreatePrintableSnippet(); ok {
-			fmt.Println(snippet)
+			if execCmdOutputFlag != "" {
+				os.WriteFile(execCmdOutputFlag, []byte(snippet), 0644)
+			} else {
+				fmt.Println(snippet)
+			}
 		}
 	},
 }
 
 func init() {
+	printCmd.PersistentFlags().StringVarP(
+		&execCmdOutputFlag,
+		"output",
+		"o",
+		"",
+		fmt.Sprintf("Write snippet to file instead of stdout"))
 	rootCmd.AddCommand(printCmd)
 }

--- a/docs/getting-started/power-setup.md
+++ b/docs/getting-started/power-setup.md
@@ -28,3 +28,27 @@ defaultRootCommand: "exec"
 
 With this setup, calling `sn` will yield the same result as `snipkit exec`. If you want to call
 the `print` command instead, type `sn print`.
+
+### Interactive ZSH Widget
+
+Similar to the history search in ZSH, it is possible to bind `snipkit print` to a keybinding that will copy the generated snippet to the clipboard.
+
+Define a function:
+
+```shell
+snipkit-snippets-widget () {
+        echoti rmkx
+        exec </dev/tty
+        local snipkit_output=$(mktemp ${TMPDIR:-/tmp}/snipkit.output.XXXXXXXX)
+        ./snipkit print -o "${snipkit_output}"
+        echoti smkx
+        cat $snipkit_output | pbcopy
+        rm -f $snipkit_output
+}
+```
+
+Bind widget to `CTRL+x x`:
+
+```shell
+bindkey "^Xx" snipkit-snippets-widget
+```


### PR DESCRIPTION
Add an option to output generated snipped to a file using `snipkit --output <FILE>`.

Update `Power Setup` documentation to include an example of configuring a ZSH widget.


https://github.com/lemoony/snipkit/assets/32794653/9f023405-3aac-4af8-898f-c07cb347e715


@lemoony, I did not update the test for this. Do you think I should do it?
