### PR TITLE
Add copy command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
+      - name: Install clipboard utilities
+        run: sudo apt-get update && sudo apt-get install -y xsel wl-clipboard
       - name: Build
         run: |
           # https://github.com/jaraco/keyring/blob/main/README.rst#using-keyring-on-headless-linux-systems

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -21,7 +21,7 @@ var copyCmd = &cobra.Command{
 
 func copyToClipboard(snippet string) {
 	if err := clipboard.WriteAll(snippet); err != nil {
-		panic(errors.Wrap(err, "failed to write to clipboard"))
+		panic(errors.Wrap(errors.WithStack(err), "failed to write to clipboard"))
 	}
 }
 

--- a/cmd/copy.go
+++ b/cmd/copy.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"emperror.dev/errors"
+	"github.com/atotto/clipboard"
+	"github.com/spf13/cobra"
+)
+
+var copyCmd = &cobra.Command{
+	Use:     "copy",
+	Aliases: []string{"cp"},
+	Short:   "Copies the snippet to the clipboard",
+	Long:    `Copies the selected snippet to the clipboard for manual execution.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		app := getAppFromContext(cmd.Context())
+		if snippet, ok := app.LookupAndCreatePrintableSnippet(); ok {
+			copyToClipboard(snippet)
+		}
+	},
+}
+
+func copyToClipboard(snippet string) {
+	if err := clipboard.WriteAll(snippet); err != nil {
+		panic(errors.Wrap(err, "failed to write to clipboard"))
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(copyCmd)
+}

--- a/cmd/copy_test.go
+++ b/cmd/copy_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"runtime"
 	"testing"
 
 	"github.com/atotto/clipboard"
@@ -18,9 +20,12 @@ func Test_Copy(t *testing.T) {
 
 	app.AssertNumberOfCalls(t, "LookupAndCreatePrintableSnippet", 1)
 
-	if content, err := clipboard.ReadAll(); err != nil {
-		assert.NoError(t, err)
-	} else {
-		assert.Equal(t, "snippet-printed", content)
+	// Workaround: Clipboard doesn't work on the CI for linux.
+	if runtime.GOOS != "linux" || os.Getenv("CI") != "true" {
+		if content, err := clipboard.ReadAll(); err != nil {
+			assert.NoError(t, err)
+		} else {
+			assert.Equal(t, "snippet-printed", content)
+		}
 	}
 }

--- a/cmd/copy_test.go
+++ b/cmd/copy_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/atotto/clipboard"
+	"github.com/stretchr/testify/assert"
+
+	mocks "github.com/lemoony/snipkit/mocks/app"
+)
+
+func Test_Copy(t *testing.T) {
+	app := mocks.App{}
+	app.On("LookupAndCreatePrintableSnippet").
+		Return("snippet-printed", true)
+
+	runExecuteTest(t, []string{"copy"}, withApp(&app))
+
+	app.AssertNumberOfCalls(t, "LookupAndCreatePrintableSnippet", 1)
+
+	if content, err := clipboard.ReadAll(); err != nil {
+		assert.NoError(t, err)
+	} else {
+		assert.Equal(t, "snippet-printed", content)
+	}
+}

--- a/cmd/helper_test.go
+++ b/cmd/helper_test.go
@@ -86,6 +86,7 @@ func runExecuteTest(t *testing.T, args []string, options ...option) {
 	}
 
 	ctx := context.Background()
+
 	if ts.app != nil {
 		ctx = context.WithValue(ctx, _appKey, ts.app)
 	}

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var printCmdCopyFlag = false
+
 var printCmd = &cobra.Command{
 	Use:   "print",
 	Short: "Prints the snippet on stdout",
@@ -21,10 +23,21 @@ var printCmd = &cobra.Command{
 
 		if snippet, ok := app.LookupAndCreatePrintableSnippet(); ok {
 			_, _ = fmt.Fprintln(os.Stdout, snippet)
+			if printCmdCopyFlag {
+				copyToClipboard(snippet)
+			}
+
 		}
 	},
 }
 
 func init() {
+	printCmd.PersistentFlags().BoolVar(
+		&printCmdCopyFlag,
+		"copy",
+		false,
+		"copies the snippet to the clipboard",
+	)
+
 	rootCmd.AddCommand(printCmd)
 }

--- a/docs/getting-started/overview.md
+++ b/docs/getting-started/overview.md
@@ -14,6 +14,7 @@ Available Commands:
   browse      Browse all snippets without executing them
   completion  Generate the autocompletion script for the specified shell
   config      Manage your snipkit configuration file
+  copy        Copies the snippet to the clipboard
   exec        Execute a snippet directly from the terminal
   help        Help about any command
   info        Provides useful information about the snipkit configuration
@@ -88,4 +89,13 @@ You can browse all available snippets without executing or printing them.
 
 ```sh title="Browse all snippets"
 snipkit browse
+```
+
+#### Copy snippet to clipboard
+
+You can copy a snippet to the clipboard in two ways:
+
+```sh title="Copy to clipboard"
+snipkit copy # Copies the snippet directly to the clipboard without printing
+snipkit print --copy # Prints the snippet on stdout and, additionally, copies it to the clipboard
 ```

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/adrg/xdg v0.5.0
 	github.com/alecthomas/chroma v0.10.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.6
 	github.com/charmbracelet/lipgloss v0.12.1
@@ -37,7 +38,6 @@ require (
 
 require (
 	github.com/alessio/shellescape v1.4.2 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/x/ansi v0.1.4 // indirect
 	github.com/charmbracelet/x/input v0.1.3 // indirect


### PR DESCRIPTION
Adds copy command as an alternative to inline commands for non-zsh shells (implemented in #256, requested in #229)